### PR TITLE
Update README to clarify PR synchronization behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ The repository uses Google's [Copybara](https://github.com/google/copybara/) to 
 
 Please see the [upstream README.md](https://github.com/stepankuzmin/copybara-sot/tree/main?tab=readme-ov-file) for more details.
 
-Every PR in this repository will be automatically synchronized to the upstream repository.
+PRs targeting the default branch in this repository will be automatically synchronized to the upstream repository.
 After changes land upstream, they're automatically propagated back to this repository! 🚀


### PR DESCRIPTION
## Summary
- Updated README.md to clarify that only PRs targeting the default branch will be synchronized to upstream

## Context
Following the recent workflow update that restricts PR notifications to only trigger for PRs targeting the default branch, this updates the documentation to match the actual behavior.