### PR TITLE
Set required Node version to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "main": "index.js",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "test": "node --test --experimental-strip-types",
     "tsc": "tsc"


### PR DESCRIPTION
We use `--experimental-strip-types` which was added in Node v22